### PR TITLE
[WIP] Update Conda recipes to support rattler-build.

### DIFF
--- a/conda_recipes/blender-4.1/deadline-cloud.yaml
+++ b/conda_recipes/blender-4.1/deadline-cloud.yaml
@@ -3,7 +3,9 @@ condaPlatforms:
     defaultSubmit: true
     sourceArchiveFilename: blender-4.1.1-linux-x64.tar.xz
     sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.1/blender-4.1.1-linux-x64.tar.xz"'
+    buildTool: rattler-build
   - platform: win-64
     defaultSubmit: false
     sourceArchiveFilename: blender-4.1.1-windows-x64.zip
     sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.1/blender-4.1.1-windows-x64.zip"'
+    buildTool: conda-build

--- a/conda_recipes/blender-4.1/recipe/meta.yaml
+++ b/conda_recipes/blender-4.1/recipe/meta.yaml
@@ -1,3 +1,6 @@
+# Recipe in conda-build format.
+# This recipe is only for Windows, see recipe.yaml for the Linux recipe in rattler-build format.
+
 {% set version = "4.1.1" %}
 {% set major_minor_version = ".".join(version.split(".")[:2]) %}
 
@@ -6,13 +9,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-linux-x64.tar.gz # [linux64]
   url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-windows-x64.zip # [win64]
-  sha256: ab2ea3fe991601a5e6bd2cda786ecaa919c0b39e0550e59978b5d40270c260d3 # [linux64]
   sha256: 40b4829888770b93aafe96875e00a12e781720010dbbad3aa898362ea3cad62c # [win64]
   folder: blender
 
 build:
+  skip: true  # [not win64]
   number: 0
   # These build options for repackaging an application
   # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html

--- a/conda_recipes/blender-4.1/recipe/recipe.yaml
+++ b/conda_recipes/blender-4.1/recipe/recipe.yaml
@@ -1,0 +1,45 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "4.1.1"
+  major_minor_version: "4.1"
+
+package:
+  name: blender
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-linux-x64.tar.xz
+      sha256: ab2ea3fe991601a5e6bd2cda786ecaa919c0b39e0550e59978b5d40270c260d3
+      target_directory: blender
+  - if: win
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-windows-x64.zip
+      sha256: 40b4829888770b93aafe96875e00a12e781720010dbbad3aa898362ea3cad62c
+      target_directory: blender
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+tests:
+  - script:
+    - blender -h
+
+about:
+  homepage: https://www.blender.org/
+  license: GPL-3.0
+  summary: >
+    Blender is the free and open source 3D creation suite. It supports the entirety of
+    the 3D pipeline—modeling, rigging, animation, simulation, rendering, compositing
+    and motion tracking, even video editing and game creation.

--- a/conda_recipes/blender-4.2/deadline-cloud.yaml
+++ b/conda_recipes/blender-4.2/deadline-cloud.yaml
@@ -1,9 +1,11 @@
 condaPlatforms:
   - platform: linux-64
     defaultSubmit: true
-    sourceArchiveFilename: blender-4.2.1-linux-x64.tar.xz
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.1-linux-x64.tar.xz"'
+    sourceArchiveFilename: blender-4.2.3-linux-x64.tar.xz
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.3-linux-x64.tar.xz"'
+    buildTool: rattler-build
   - platform: win-64
     defaultSubmit: false
-    sourceArchiveFilename: blender-4.2.1-windows-x64.zip
-    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.1-windows-x64.zip"'
+    sourceArchiveFilename: blender-4.2.3-windows-x64.zip
+    sourceDownloadInstructions: 'Run "curl -LO https://download.blender.org/release/Blender4.2/blender-4.2.3-windows-x64.zip"'
+    buildTool: conda-build

--- a/conda_recipes/blender-4.2/recipe/meta.yaml
+++ b/conda_recipes/blender-4.2/recipe/meta.yaml
@@ -1,4 +1,7 @@
-{% set version = "4.2.1" %}
+# Recipe in conda-build format.
+# This recipe is only for Windows, see recipe.yaml for the Linux recipe in rattler-build format.
+
+{% set version = "4.2.3" %}
 {% set major_minor_version = ".".join(version.split(".")[:2]) %}
 
 package:
@@ -6,13 +9,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-linux-x64.tar.gz # [linux64]
   url: https://download.blender.org/release/Blender{{major_minor_version}}/blender-{{version}}-windows-x64.zip # [win64]
-  sha256: be0fbaa0c1e52d4552023220b4c67351efbb707cac49bb381fcbee2182447005 # [linux64]
-  sha256: 46b9d27c2406454c68842d1790515732be385719e844f6b283e3c78186f9ffce # [win64]
+  sha256: 7f8be9b1dc904e7689b3112659791c29cc9ed9d46ce57c4ea5b31a0621489b3a # [win64]
   folder: blender
 
 build:
+  skip: true  # [not win64]
   number: 0
   # These build options for repackaging an application
   # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html

--- a/conda_recipes/blender-4.2/recipe/recipe.yaml
+++ b/conda_recipes/blender-4.2/recipe/recipe.yaml
@@ -1,0 +1,45 @@
+# Recipe in rattler-build format.
+# See https://prefix-dev.github.io/rattler-build/latest/
+
+context:
+  version: "4.2.3"
+  major_minor_version: "4.2"
+
+package:
+  name: blender
+  version: ${{ version }}
+
+source:
+  - if: linux
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-linux-x64.tar.xz
+      sha256: 3a64efd1982465395abab4259b4091d5c8c56054c7267e9633e4f702a71ea3f4
+      target_directory: blender
+  - if: win
+    then:
+      url: https://download.blender.org/release/Blender${{ major_minor_version }}/blender-${{ version }}-windows-x64.zip
+      sha256: 7f8be9b1dc904e7689b3112659791c29cc9ed9d46ce57c4ea5b31a0621489b3a
+      target_directory: blender
+
+build:
+  number: 0
+  # These build options for repackaging an application
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html
+  prefix_detection:
+    ignore_binary_files: True
+  dynamic_linking:
+    binary_relocation: False
+    missing_dso_allowlist:
+    - "**"
+
+tests:
+  - script:
+    - blender -h
+
+about:
+  homepage: https://www.blender.org/
+  license: GPL-3.0
+  summary: >
+    Blender is the free and open source 3D creation suite. It supports the entirety of
+    the 3D pipeline—modeling, rigging, animation, simulation, rendering, compositing
+    and motion tracking, even video editing and game creation.

--- a/conda_recipes/conda_build_linux_package/scripts/build-package.py
+++ b/conda_recipes/conda_build_linux_package/scripts/build-package.py
@@ -1,15 +1,36 @@
-import sys
 import argparse
+import glob
+import json
+import os
+import shlex
 import shutil
 import subprocess
-import yaml
-import json
-import boto3
-import glob
-import shlex
+import sys
 from pathlib import Path
-from botocore.exceptions import ClientError
 from urllib.parse import urlparse
+
+import boto3
+import yaml
+from botocore.exceptions import ClientError
+
+
+def print_command(command):
+    """Print a command with shlex, splitting each option to a separate line."""
+
+    # Split the command, starting a new list for each option starting with "-"
+    split_commands = [[command[0]]]
+    for entry in command[1:]:
+        if entry.startswith("-"):
+            split_commands.append([])
+        split_commands[-1].append(entry)
+
+    # Print the command on multiple lines
+    suffix = " \\" if len(split_commands) > 1 else ""
+    print(f"+ {shlex.join(split_commands[0])}{suffix}")
+    for index in range(1, len(split_commands)):
+        if index == len(split_commands) - 1:
+            suffix = ""
+        print(f"+     {shlex.join(split_commands[index])}{suffix}")
 
 
 def parse_s3_channel_url(s3_url):
@@ -31,14 +52,10 @@ def get_next_build_number(package_name, package_version, conda_platform, channel
         "--spec",
         f"{package_name}=={package_version}",
     ]
-    print(f"+ {shlex.join(command)}")
-    package_search_result = subprocess.run(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
+    print_command(command)
+    package_search_result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    print(package_search_result.stdout.decode(errors="replace").replace("\r\n", "\n"))
     package_search_result_json = json.loads(package_search_result.stdout)
-    print(json.dumps(package_search_result_json, indent=1))
 
     if package_search_result.returncode == 0 and package_name in package_search_result_json:
         build_number = max(package["build_number"] for package in package_search_result_json[package_name]) + 1
@@ -53,14 +70,20 @@ def get_next_build_number(package_name, package_version, conda_platform, channel
     return build_number
 
 
-def get_channel_options(s3_channel_bucket, s3_channel_prefix, conda_channels, s3_client):
+def get_channel_options(
+    s3_channel_bucket,
+    s3_channel_prefix,
+    proxy_s3_conda_channel,
+    conda_channels,
+    s3_client,
+):
     channel_options = []
     try:
         repodata_key = f"{s3_channel_prefix}/noarch/repodata.json.zst"
         print(f"Checking whether the S3 channel already has an index by looking for s3://{s3_channel_bucket}/{repodata_key}")
         s3_client.head_object(Bucket=s3_channel_bucket, Key=repodata_key)
-        print(f"Found an index, adding s3://{s3_channel_bucket}/{s3_channel_prefix} to the input channel list")
-        channel_options.extend(["-c", f"s3://{s3_channel_bucket}/{s3_channel_prefix}"])
+        print(f"Found an index, adding {proxy_s3_conda_channel} to the input channel list")
+        channel_options.extend(["-c", proxy_s3_conda_channel])
     except ClientError as exc:
         print(exc)
         error_code = int(exc.response["ResponseMetadata"]["HTTPStatusCode"])
@@ -74,87 +97,215 @@ def get_channel_options(s3_channel_bucket, s3_channel_prefix, conda_channels, s3
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--recipe-dir", required=True)
+    parser.add_argument("--build-tool", required=True, choices=("conda-build", "rattler-build"))
     parser.add_argument("--conda-platform", required=True)
     parser.add_argument("--override-package-name")
     parser.add_argument("--conda-channels", default="")
     parser.add_argument("--conda-bld-dir", required=True)
     parser.add_argument("--s3-conda-channel", required=True)
+    parser.add_argument("--proxy-s3-conda-channel", required=True)
     parser.add_argument("--override-prefix-length")
     parser.add_argument("--override-source-archive1")
     parser.add_argument("--override-source-archive2")
-    parser.add_argument("--conda-build-config-file")
+    parser.add_argument("--variant-config-file")
     args = parser.parse_args()
 
     session = boto3.Session()
     s3_client = session.client("s3")
 
-    if args.conda_build_config_file:
-        shutil.copy(args.conda_build_config_file, Path(args.recipe_dir) / "conda_build_config.yaml")
+    if args.variant_config_file:
+        print("Using the following additional variant config:")
+        print(Path(args.variant_config_file).read_text())
+        print()
 
     s3_channel_bucket, s3_channel_prefix = parse_s3_channel_url(args.s3_conda_channel)
 
     # Make sure the package build starts with a clean conda-bld directory
     command = ["conda", "build", "purge"]
-    print(f"+ {shlex.join(command)}")
+    print_command(command)
     subprocess.check_call(command)
+    if os.path.isdir(args.conda_bld_dir):
+        shutil.rmtree(args.conda_bld_dir)
 
-    channel_options = get_channel_options(s3_channel_bucket, s3_channel_prefix, args.conda_channels, s3_client)
+    # Create the "-c CHANNEL_NAME" options
+    channel_options = get_channel_options(
+        s3_channel_bucket,
+        s3_channel_prefix,
+        args.proxy_s3_conda_channel,
+        args.conda_channels,
+        s3_client,
+    )
+    variant_config_option = []
+    if args.variant_config_file:
+        variant_config_option = ["-m", args.variant_config_file]
 
-    command = ["conda", "render", "--no-source", "-f", "rendered_meta.yaml", *channel_options, args.recipe_dir]
-    print(f"+ {shlex.join(command)}")
-    subprocess.check_call(command)
+    # Render the recipe, to substitute any jinja templating. We can take and modify literal
+    # values from the rendered recipe to apply the customizations specified by job parameters.
+    if args.build_tool == "conda-build":
+        recipe_file = f"{args.recipe_dir}/meta.yaml"
+        command = [
+            "conda",
+            "render",
+            *variant_config_option,
+            "--no-source",
+            "-f",
+            "rendered_meta.yaml",
+            *channel_options,
+            "--override-channels",
+            args.recipe_dir,
+        ]
+        print_command(command)
+        subprocess.check_call(command)
 
-    rendered_meta_text = Path("rendered_meta.yaml").read_text()
-    print(rendered_meta_text)
-    rendered_meta = yaml.safe_load(rendered_meta_text)
+        rendered_meta_text = Path("rendered_meta.yaml").read_text()
+        print(rendered_meta_text)
+        rendered_recipe = yaml.safe_load(rendered_meta_text)
+    elif args.build_tool == "rattler-build":
+        recipe_file = f"{args.recipe_dir}/recipe.yaml"
+        updated_recipe_file = f"{args.recipe_dir}/updated_recipe.yaml"
 
-    package_name = rendered_meta["package"]["name"]
+        # Update environment variables to use a session anchored tmp folder.
+        # On Deadline workers, TMPDIR is set to /tmp, and a small scratch space.
+        session_temp_dir = f"{args.conda_bld_dir}/tmp"
+        os.mkdir(args.conda_bld_dir)
+        os.mkdir(session_temp_dir)
+        env_vars = os.environ.copy()
+        env_vars["TMPDIR"] = session_temp_dir
+
+        command = [
+            "rattler-build",
+            "build",
+            "--render-only",
+            "--recipe",
+            recipe_file,
+            *variant_config_option,
+            "--output-dir",
+            args.conda_bld_dir,
+            "--verbose",
+            *channel_options,
+        ]
+        print_command(command)
+        recipe_render_result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env_vars)
+        print(recipe_render_result.stdout.decode(errors="replace").replace("\r\n", "\n"))
+        if recipe_render_result.returncode != 0:
+            print("stderr:")
+            print(recipe_render_result.stderr.decode(errors="replace").replace("\r\n", "\n"))
+            print(f"ERROR: Process exited with return code {recipe_render_result.returncode}")
+            sys.exit(1)
+        recipe_list = json.loads(recipe_render_result.stdout)
+        if len(recipe_list) != 1:
+            print(f"ERROR: The options selected resulted in more than one rendered recipe, ensure only one variant is specified.")
+            sys.exit(1)
+        rendered_recipe = recipe_list[0]["recipe"]
+    else:
+        print(f"ERROR: Unsupported build tool {args.build_tool}")
+        sys.exit(1)
+
+    # Replace values in the rendered recipe
     if args.override_package_name:
-        package_name = args.override_package_name
+        rendered_recipe["package"]["name"] = args.override_package_name
+    package_name = rendered_recipe["package"]["name"]
 
-    package_version = rendered_meta["package"]["version"]
+    package_version = rendered_recipe["package"]["version"]
 
-    build_number = get_next_build_number(package_name, package_version, args.conda_platform, channel_options)
+    rendered_recipe["build"]["number"] = get_next_build_number(package_name, package_version, args.conda_platform, channel_options)
+    build_number = rendered_recipe["build"]["number"]
     print(f"openjd_status: Selected build number {build_number}")
 
-    recipe_clobber = {"build": {"number": build_number}}
-    if args.override_package_name:
-        recipe_clobber["package"] = {}
-        recipe_clobber["package"]["name"] = args.override_package_name
-    if isinstance(rendered_meta["source"], dict):
-        if args.override_source_archive1:
-            recipe_clobber["source"] = {}
-            recipe_clobber["source"]["url"] = args.override_source_archive1
-    elif isinstance(rendered_meta["source"], list):
-        rendered_source = rendered_meta["source"]
-        if args.override_source_archive1 or args.override_source_archive2:
-            if args.override_source_archive1:
-                rendered_source[0]["url"] = args.override_source_archive1
-            if args.override_source_archive2:
-                rendered_source[1]["url"] = args.override_source_archive2
-            recipe_clobber["source"] = rendered_source
-    else:
-        raise RuntimeError("The rendered meta.yaml's source field was not a string or a list.")
+    # Validate that the provided input source archive files exist
+    if args.override_source_archive1:
+        if not os.path.isfile(args.override_source_archive1):
+            print(f"ERROR: Override source archive 1 does not exist: {args.override_source_archive1}")
+            sys.exit(1)
+    if args.override_source_archive2:
+        if not os.path.isfile(args.override_source_archive2):
+            print(f"ERROR: Override source archive 2 does not exist: {args.override_source_archive2}")
+            sys.exit(1)
 
-    Path("recipe_clobber.yaml").write_text(yaml.safe_dump(recipe_clobber))
+    # Substitute the override archives into the recipe
+    if "source" in rendered_recipe:
+        if isinstance(rendered_recipe["source"], dict):
+            if args.override_source_archive1:
+                rendered_recipe["source"] = {}
+                if args.build_tool == "conda-build":
+                    rendered_recipe["source"]["url"] = args.override_source_archive1
+                else:
+                    del rendered_recipe["source"]["url"]
+                    rendered_recipe["source"]["path"] = args.override_source_archive1
+        elif isinstance(rendered_recipe["source"], list):
+            rendered_source = rendered_recipe["source"]
+            if args.override_source_archive1 or args.override_source_archive2:
+                if args.override_source_archive1:
+                    if args.build_tool == "conda-build":
+                        rendered_source[0]["url"] = args.override_source_archive1
+                    else:
+                        del rendered_source[0]["url"]
+                        rendered_source[0]["path"] = args.override_source_archive1
+                if args.override_source_archive2:
+                    if args.build_tool == "conda-build":
+                        rendered_source[1]["url"] = args.override_source_archive2
+                    else:
+                        del rendered_source[1]["url"]
+                        rendered_source[1]["path"] = args.override_source_archive2
+                rendered_recipe["source"] = rendered_source
+        else:
+            raise RuntimeError("The rendered recipe's source field was not a string or a list.")
+
+    # Save the rendered recipe with modifications
+    if args.build_tool == "conda-build":
+        recipe_clobber = {
+            "package": {"name": rendered_recipe["package"]["name"]},
+            "build": {"number": rendered_recipe["build"]["number"]},
+            "source": rendered_recipe["source"],
+        }
+        print("Clobber file:")
+        print(json.dumps(recipe_clobber, indent=1))
+        Path("recipe_clobber.yaml").write_text(json.dumps(recipe_clobber))
+    else:
+        with open(updated_recipe_file, "w") as fh:
+            json.dump(rendered_recipe, fh)
 
     prefix_length_option = []
-    if args.override_prefix_length:
+    if args.override_prefix_length and args.override_prefix_length != "0":
+        if args.build_tool == "rattler-build":
+            print("ERROR: The rattler-build package build tool does not support overriding the prefix length.")
+            sys.exit(1)
         prefix_length_option = ["--prefix-length", f"{args.override_prefix_length}"]
 
-    command = [
-        "conda",
-        "build",
-        "--no-anaconda-upload",
-        *prefix_length_option,
-        *channel_options,
-        "--clobber-file",
-        "recipe_clobber.yaml",
-        args.recipe_dir,
-    ]
-    print(f"+ {shlex.join(command)}")
-    subprocess.check_call(command)
+    # Run the package build tool
+    if args.build_tool == "conda-build":
+        command = [
+            "conda",
+            "build",
+            "--no-anaconda-upload",
+            *prefix_length_option,
+            *variant_config_option,
+            *channel_options,
+            "--clobber-file",
+            "recipe_clobber.yaml",
+            args.recipe_dir,
+        ]
+    else:
+        command = [
+            "rattler-build",
+            "build",
+            "--recipe",
+            updated_recipe_file,
+            *variant_config_option,
+            "--output-dir",
+            args.conda_bld_dir,
+            "--verbose",
+            *prefix_length_option,
+            *channel_options,
+        ]
+    print_command(command)
+    subprocess.check_call(command, env=env_vars)
 
+    if args.build_tool == "rattler-build":
+        # Remove the recipe file created with modifications
+        os.unlink(updated_recipe_file)
+
+    # Upload all the built packages
     for subdir in [args.conda_platform, "noarch"]:
         for package in glob.glob(str(Path(args.conda_bld_dir) / subdir / "*.conda")):
             package_name = Path(package).name

--- a/conda_recipes/conda_build_linux_package/scripts/enter-proxy-s3-conda-channels.sh
+++ b/conda_recipes/conda_build_linux_package/scripts/enter-proxy-s3-conda-channels.sh
@@ -1,0 +1,100 @@
+#!/bin/env bash
+set -euo pipefail
+
+# The rattler-build tool does not support S3 conda channels. Therefore,
+# this job uses s3-mountpoint to mount any conda channels that start with s3://.
+#
+# Publishes the environment variables CONDA_CHANNELS and S3_CONDA_CHANNEL
+# with the s3:// channels rewritten to file://. Also publishes S3_PROXY_ROOT
+# for the exit-proxy-s3-conda-channels.sh script to use for clean-up.
+
+CONDA_CHANNELS=
+S3_CONDA_CHANNEL=
+BUILD_TOOL=
+
+# Parse the CLI arguments
+while [ $# -gt 0 ]; do
+    case "${1}" in
+    --conda-channels) CONDA_CHANNELS="$2" ; shift 2 ;;
+    --s3-conda-channel) S3_CONDA_CHANNEL="$2" ; shift 2 ;;
+    --build-tool) BUILD_TOOL="$2" ; shift 2 ;;
+    *) echo "Unexpected option: $1" ; exit 1 ;;
+  esac
+done
+
+if [ -z "$S3_CONDA_CHANNEL" ]; then
+    echo "ERROR: Option --s3-conda-channel is required."
+    exit 1
+fi
+
+if [ -z "$BUILD_TOOL" ]; then
+    echo "ERROR: Option --build-tool is required."
+    exit 1
+fi
+
+if [ "$BUILD_TOOL" != "conda-build" ] && [ "$BUILD_TOOL" != "rattler-build" ]; then
+    echo "ERROR: Option --build-tool must be either conda-build or rattler-build."
+    exit 1
+fi
+
+if [ "$BUILD_TOOL" == "conda-build" ]; then
+    echo "The conda-build tool support s3:// channels, no proxy is required."
+    echo "openjd_env: CONDA_CHANNELS=$CONDA_CHANNELS"
+    echo "openjd_env: S3_CONDA_CHANNEL=$S3_CONDA_CHANNEL"
+    exit 0
+fi
+
+# Choose a root directory for mounting the S3 channels
+if [[ "$(uname)" == Linux ]]; then
+    mkdir -p proxy-s3
+    S3_PROXY_ROOT=$(pwd)/proxy-s3
+else
+    echo "ERROR: The S3 conda channel proxy is based on s3-mountpoint, only available on Linux."
+    exit 1
+fi
+echo "openjd_env: S3_PROXY_ROOT=$S3_PROXY_ROOT"
+mkdir -p "$S3_PROXY_ROOT"
+
+# Install an error handler to unmount any mounted drives
+function unmount_s3_proxy_on_error {
+    if [ ! "$1" = "0" ]; then
+        set +e
+        for MOUNTPOINT in "$S3_PROXY_ROOT"/*; do
+            fusermount -u $MOUNTPOINT
+            rmdir $MOUNTPOINT
+        done
+        set -e
+    fi
+}
+trap 'unmount_s3_proxy_on_error $?' EXIT
+
+function mount_s3_proxy {
+    # Checks if the channel is s3:// and mounts it with s3-mountpoint if so.
+    # Outputs new channel name to UPDATED_CHANNEL.
+    local CHANNEL=$1
+
+    if [[ "$CHANNEL" =~ ^s3://([^/]+)/(.*)/?$ ]]; then
+        local S3_CHANNEL_BUCKET=${BASH_REMATCH[1]}
+        local S3_CHANNEL_PREFIX=${BASH_REMATCH[2]}
+        local CHANNEL_DIR="${S3_CHANNEL_BUCKET}_${S3_CHANNEL_PREFIX//\//_}"
+        mkdir -p "$S3_PROXY_ROOT/$CHANNEL_DIR"
+        mount-s3 --prefix $S3_CHANNEL_PREFIX/ \
+            --read-only \
+            $S3_CHANNEL_BUCKET "$S3_PROXY_ROOT/$CHANNEL_DIR"
+        UPDATED_CHANNEL="file://$S3_PROXY_ROOT/$CHANNEL_DIR"
+    else
+        UPDATED_CHANNEL="$CHANNEL"
+    fi
+}
+
+# Mount all the S3 conda channels, and rewrite the channel names
+RESULT_CONDA_CHANNELS=
+for CHANNEL in $CONDA_CHANNELS; do
+    mount_s3_proxy "$CHANNEL"
+    RESULT_CONDA_CHANNELS="$RESULT_CONDA_CHANNELS $UPDATED_CHANNEL"
+done
+echo "openjd_env: CONDA_CHANNELS=$RESULT_CONDA_CHANNELS"
+
+# Mount the S3 conda channel and rewrite its name
+mount_s3_proxy $S3_CONDA_CHANNEL
+echo "openjd_env: S3_CONDA_CHANNEL=$UPDATED_CHANNEL"

--- a/conda_recipes/conda_build_linux_package/scripts/exit-proxy-s3-conda-channels.sh
+++ b/conda_recipes/conda_build_linux_package/scripts/exit-proxy-s3-conda-channels.sh
@@ -1,0 +1,15 @@
+#!/bin/env bash
+set -euo pipefail
+
+if [ -z "${S3_PROXY_ROOT:-}" ]; then
+    echo "No S3 proxy was performed."
+    exit 0
+fi
+
+set +e
+for MOUNTPOINT in "$S3_PROXY_ROOT"/*; do
+    echo "Unmounting $MOUNTPOINT"
+    fusermount -u $MOUNTPOINT
+    rmdir $MOUNTPOINT
+done
+set -e

--- a/conda_recipes/conda_build_linux_package/scripts/reindex-conda-channel.sh
+++ b/conda_recipes/conda_build_linux_package/scripts/reindex-conda-channel.sh
@@ -63,13 +63,16 @@ for CHANNEL_DIR in $CHANNEL_DIRS; do
         echo "Found $(basename $CHANNEL_DIR) in the channel"
         mkdir -p $CHANNEL_INDEXING_DIR/$(basename $CHANNEL_DIR)
         for PACKAGE in $(cd $CHANNEL_DIR; \
-                        shopt -s nullglob; echo *.conda); do
+                        shopt -s nullglob; echo *.conda *.tar.bz2); do
             ln -r -s $CHANNEL_DIR/$PACKAGE \
                 $CHANNEL_INDEXING_DIR/$(basename $CHANNEL_DIR)/$PACKAGE
         done
         if [ -f "$CHANNEL_DIR/.cache/cache.db" ]; then
             mkdir -p "$CHANNEL_INDEXING_DIR/$(basename $CHANNEL_DIR)/.cache"
             cp "$CHANNEL_DIR/.cache/cache.db" "$CHANNEL_INDEXING_DIR/$(basename $CHANNEL_DIR)/.cache/"
+        fi
+        if [ -f "$CHANNEL_DIR/patch_instructions.json" ]; then
+            cp "$CHANNEL_DIR/patch_instructions.json" "$CHANNEL_INDEXING_DIR/$(basename $CHANNEL_DIR)/"
         fi
     fi
 done

--- a/conda_recipes/conda_build_linux_package/scripts/s3-object-mutex.py
+++ b/conda_recipes/conda_build_linux_package/scripts/s3-object-mutex.py
@@ -85,9 +85,7 @@ def _mutex_get_lock_data(mutex_timeout_seconds=MUTEX_TIMEOUT_SECONDS):
         return (None, None)
 
     time_until_expiry = (
-        response["LastModified"]
-        + datetime.timedelta(seconds=mutex_timeout_seconds)
-        - datetime.datetime.now(tz=datetime.timezone.utc)
+        response["LastModified"] + datetime.timedelta(seconds=mutex_timeout_seconds) - datetime.datetime.now(tz=datetime.timezone.utc)
     )
     if time_until_expiry <= datetime.timedelta(seconds=0):
         # If the object hasn't been refreshed within the timeout, it's not locked. This
@@ -107,9 +105,7 @@ def _mutex_wait_while_locked():
     """
     lock_data, time_until_expiry = _mutex_get_lock_data()
     while lock_data is not None:
-        print(
-            f"Waiting, the lock for mutex s3://{s3_bucket_name}/{s3_lock_object} expires in {time_until_expiry}, info:"
-        )
+        print(f"Waiting, the lock for mutex s3://{s3_bucket_name}/{s3_lock_object} expires in {time_until_expiry}, info:")
         pprint(lock_data)
         time.sleep(MUTEX_WAIT_POLLING_SECONDS)
         lock_data, time_until_expiry = _mutex_get_lock_data()
@@ -151,9 +147,7 @@ def enter():
             continue
 
         # Filter out expired objects
-        expiry = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(
-            seconds=MUTEX_ACQUISITION_TIMEOUT_SECONDS
-        )
+        expiry = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(seconds=MUTEX_ACQUISITION_TIMEOUT_SECONDS)
         s3_objects = [obj for obj in all_s3_objects if obj["LastModified"] > expiry]
 
         # Sort the objects oldest first, then by key
@@ -176,9 +170,7 @@ def enter():
     s3_client.put_object(Bucket=s3_bucket_name, Key=s3_lock_object, Body=body)
 
     # Delete our lock acquisition object and any expired ones
-    delete_s3_objects = [
-        obj for obj in all_s3_objects if obj["LastModified"] <= expiry or obj["Key"] == s3_lock_acquisition_object
-    ]
+    delete_s3_objects = [obj for obj in all_s3_objects if obj["LastModified"] <= expiry or obj["Key"] == s3_lock_acquisition_object]
     for obj in delete_s3_objects:
         print(f"Deleting object s3://{s3_bucket_name}/{obj['Key']}")
         s3_client.delete_object(Bucket=s3_bucket_name, Key=obj["Key"])

--- a/conda_recipes/conda_build_linux_package/template.yaml
+++ b/conda_recipes/conda_build_linux_package/template.yaml
@@ -12,6 +12,15 @@ description: |
 
 parameterDefinitions:
 # Group: Conda Package Recipe
+- name: BuildTool
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Package Build Tool
+    groupLabel: Conda Package Recipe
+  description: Choose the build tool to use for the recipe (conda-build or rattler-build).
+  default: conda-build
+  allowedValues: ["conda-build", "rattler-build"]
 - name: RecipeName
   description: The name of the recipe being built.
   userInterface:
@@ -77,16 +86,16 @@ parameterDefinitions:
     control: SPIN_BOX
     label: Override Prefix Length
     groupLabel: Conda Package Recipe
-- name: CondaBuildConfigFile
+- name: VariantConfigFile
   description: |
-    If provided, this is saved as the conda_build_config.yaml file for the conda package build.
+    If provided, this is used as the variant config for the conda package build.
   type: PATH
   objectType: FILE
   dataFlow: IN
   default: ""
   userInterface:
     control: CHOOSE_INPUT_FILE
-    label: Conda-build config YAML file
+    label: Variant config YAML file
     groupLabel: Conda Package Recipe
 
 # Group: Conda Channel
@@ -124,21 +133,21 @@ parameterDefinitions:
   type: STRING
   default: ""
 
-# Group: Conda-build Env
-- name: CondaBuildEnvName
-  description: The name of the Conda virtual environment with conda-build installed.
+# Group: Package Build Env
+- name: PackageBuildEnvName
+  description: The name of the Conda virtual environment with conda-build and rattler-build installed.
   userInterface:
     control: LINE_EDIT
-    label: Conda-build Env Name
-    groupLabel: Conda-build Env
+    label: Package Build Env Name
+    groupLabel: Package Build Env
   type: STRING
-  default: "CondaBuildEnv"
-- name: ReuseCondaBuildEnv
+  default: "PackageBuildEnv"
+- name: ReusePackageBuildEnv
   description: Whether to reuse the Conda virtual environment for conda-build or not.
   userInterface:
     control: CHECK_BOX
     label: Reuse the named Conda Build environment.
-    groupLabel: Conda-build Env
+    groupLabel: Package Build Env
   type: STRING
   default: "1"
   allowedValues: ["1", "0"]
@@ -155,7 +164,7 @@ parameterDefinitions:
 
 jobEnvironments:
 
-- name: CondaBuild Env
+- name: Package Build Env
   variables:
     # Tell Qt applications to run off-screen.
     QT_QPA_PLATFORM: offscreen
@@ -166,11 +175,13 @@ jobEnvironments:
       onEnter:
         command: "bash"
         args:
-        - '{{Param.JobScriptDir}}/enter-conda-build-env.sh'
+        - '{{Param.JobScriptDir}}/enter-package-build-env.sh'
         - '--env-name'
-        - '{{Param.CondaBuildEnvName}}'
+        - '{{Param.PackageBuildEnvName}}'
         - '--conda-bld-dir'
         - '{{Session.WorkingDirectory}}/conda-bld'
+        - '--reuse-env'
+        - '{{Param.ReusePackageBuildEnv}}'
 
 steps:
 
@@ -183,37 +194,56 @@ steps:
 
     meta:
       perStepParameters:
+      - BuildTool
       - OverrideSourceArchive1
       - OverrideSourceArchive2
       - CondaPlatform
-      - CondaBuildConfigFile
+      - VariantConfigFile
+
+  stepEnvironments:
+  - name: S3 Conda Channels
+    script:
+      actions:
+        onEnter:
+          command: "bash"
+          args:
+          - '{{Param.JobScriptDir}}/enter-proxy-s3-conda-channels.sh'
+          - '--build-tool'
+          - '{{Param.BuildTool}}'
+          - '--conda-channels'
+          - '{{Param.CondaChannels}}'
+          - '--s3-conda-channel'
+          - '{{Param.S3CondaChannel}}'
+        onExit:
+          command: "bash"
+          args:
+          - '{{Param.JobScriptDir}}/exit-proxy-s3-conda-channels.sh'
 
   script:
     actions:
       onRun:
-        command: python
-        args:
-        - '{{Param.JobScriptDir}}/build-package.py'
-        - '--conda-bld-dir'
-        - '{{Session.WorkingDirectory}}/conda-bld'
-        - '--conda-platform'
-        - '{{Param.CondaPlatform}}'
-        - '--conda-channels'
-        - '{{Param.CondaChannels}}'
-        - '--s3-conda-channel'
-        - '{{Param.S3CondaChannel}}'
-        - '--override-prefix-length'
-        - '{{Param.OverridePrefixLength}}'
-        - '--recipe-dir'
-        - '{{Param.RecipeDir}}'
-        - '--override-package-name'
-        - '{{Param.OverridePackageName}}'
-        - '--override-source-archive1'
-        - '{{Param.OverrideSourceArchive1}}'
-        - '--override-source-archive2'
-        - '{{Param.OverrideSourceArchive2}}'
-        - '--conda-build-config-file'
-        - '{{Param.CondaBuildConfigFile}}'
+        command: "bash"
+        args: ["{{Task.File.Run}}"]
+    embeddedFiles:
+    - name: Run
+      type: TEXT
+      data: |
+        #!/bin/env bash
+        set -xeuo pipefail
+
+        python '{{Param.JobScriptDir}}/build-package.py' \
+            --build-tool '{{Param.BuildTool}}' \
+            --conda-bld-dir '{{Session.WorkingDirectory}}/conda-bld' \
+            --conda-platform '{{Param.CondaPlatform}}' \
+            --conda-channels "$CONDA_CHANNELS" \
+            --s3-conda-channel '{{Param.S3CondaChannel}}' \
+            --proxy-s3-conda-channel "$S3_CONDA_CHANNEL" \
+            --override-prefix-length '{{Param.OverridePrefixLength}}' \
+            --recipe-dir '{{Param.RecipeDir}}' \
+            --override-package-name '{{Param.OverridePackageName}}' \
+            --override-source-archive1 '{{Param.OverrideSourceArchive1}}' \
+            --override-source-archive2 '{{Param.OverrideSourceArchive2}}' \
+            --variant-config-file '{{Param.VariantConfigFile}}'
 
   hostRequirements:
     # Host requirements for the linux-64 conda platform

--- a/conda_recipes/submit-package-job-script.py
+++ b/conda_recipes/submit-package-job-script.py
@@ -7,6 +7,8 @@ Installation Requirements:
 * The `deadline` library installed into Python.
 """
 import argparse
+import fnmatch
+import json
 import os
 import re
 import shutil
@@ -28,8 +30,9 @@ def validate_recipe(recipe_dir):
         raise RuntimeError(f"The recipe directory does not exist: {recipe_dir}.")
 
     meta_yaml_file = recipe_dir / "recipe" / "meta.yaml"
-    if not meta_yaml_file.is_file():
-        raise RuntimeError(f"The recipe metadata file does not exist: {meta_yaml_file}.")
+    recipe_yaml_file = recipe_dir / "recipe" / "recipe.yaml"
+    if not meta_yaml_file.is_file() and not recipe_yaml_file.is_file():
+        raise RuntimeError(f"No meta.yaml or recipe.yaml exists in {recipe_dir}.")
 
     submit_yaml_file = recipe_dir / "deadline-cloud.yaml"
     if not submit_yaml_file.is_file():
@@ -121,10 +124,11 @@ def extract_job_entity(job_template, entity_type, entity_name):
         if entity["name"] == entity_name:
             # Filter the job's parameters to just the ones referenced by the environment
             parameter_names = find_referenced_parameters(entity)
-            parameter_defs = [
-                param for param in job_template["parameterDefinitions"] if param["name"] in parameter_names
-            ]
-            result = {"parameterDefinitions": deepcopy(parameter_defs), "entity": deepcopy(entity)}
+            parameter_defs = [param for param in job_template["parameterDefinitions"] if param["name"] in parameter_names]
+            result = {
+                "parameterDefinitions": deepcopy(parameter_defs),
+                "entity": deepcopy(entity),
+            }
 
             # Get the entity's metadata, which is YAML in the description starting from a line
             # containing only the content "meta:"
@@ -140,34 +144,39 @@ def extract_job_entity(job_template, entity_type, entity_name):
 
             return result
 
-    raise RuntimeError(
-        f"Job template does not have an entity named {entity_name!r} to extract from the {entity_type} list"
-    )
+    raise RuntimeError(f"Job template does not have an entity named {entity_name!r} to extract from the {entity_type} list")
 
 
-def get_recipe_conda_platforms(*, conda_platforms_meta, conda_platform_names, all_platforms):
+def get_recipe_conda_platforms(*, conda_platforms_meta, conda_platform_patterns):
     if not conda_platforms_meta:
         raise RuntimeError("The recipe's deadline-cloud.yaml doesn't have a condaPlatforms item")
+    all_platform_names = set()
     for conda_platform in conda_platforms_meta:
         if "variant" in conda_platform:
             conda_platform["name"] = f"{conda_platform['platform']}-{conda_platform['variant']}"
         else:
             conda_platform["name"] = conda_platform["platform"]
 
+        # Add the name into the list of all names, checking for errors in the input yaml.
+        if conda_platform["name"] in all_platform_names:
+            raise RuntimeError(f"The recipe's deadline-cloud.yaml has platform/variant {conda_platform['name']} listed multiple times")
+        all_platform_names.add(conda_platform["name"])
+
     # Get the conda platforms to submit. If provided at the CLI, they must select from the ones specified
     # in deadline-cloud.yaml, otherwise it's all the default ones from there.
-    if conda_platform_names:
-        requested_conda_platform_names = set(conda_platform_names)
-        # Validate that all the requested conda platforms are supported
-        supported_conda_platform_names = {p["name"] for p in conda_platforms_meta}
-        for platform_name in requested_conda_platform_names:
-            if platform_name not in supported_conda_platform_names:
+    if conda_platform_patterns:
+        requested_conda_platform_names = set()
+        for pattern in conda_platform_patterns:
+            matched_names = [name for name in all_platform_names if fnmatch.fnmatchcase(name, pattern)]
+            # Validate that each pattern matched at least one name
+            if len(matched_names) == 0:
                 raise RuntimeError(
-                    f"The requested conda platform[-variant] option {platform_name!r} is not in {sorted(supported_conda_platform_names)}"
+                    f"The requested conda platform[-variant] glob pattern {pattern!r} did not match any of {sorted(all_platform_names)}"
                 )
-        # Filter to the requested conda platforms
+            requested_conda_platform_names.update(matched_names)
+        # Filter to the names that matched
         conda_platforms_meta = [p for p in conda_platforms_meta if p["name"] in requested_conda_platform_names]
-    elif not all_platforms:
+    else:
         # Filter to the conda platforms with field "defaultSubmit" set to True
         conda_platforms_meta = [p for p in conda_platforms_meta if p.get("defaultSubmit")]
 
@@ -189,6 +198,7 @@ def set_queue_in_config(queue_name_prefix, config):
 
 def create_job_bundle(
     *,
+    default_build_tool,
     job_bundle_dir,
     recipe_dir,
     archive_file_dir,
@@ -198,25 +208,25 @@ def create_job_bundle(
     s3_channel_prefix,
     conda_platforms,
 ):
-    # Read the build_linux_package template, and then decompose it into pieces
+    # Read the conda_build_linux_package template, and then decompose it into pieces
     build_linux_package_bundle_dir = Path(__file__).parent / "conda_build_linux_package"
     build_linux_package_template = yaml.safe_load((build_linux_package_bundle_dir / "template.yaml").read_text())
     parameter_values = {
         item["name"]: item["value"]
-        for item in yaml.safe_load((build_linux_package_bundle_dir / "parameter_values.yaml").read_text())[
-            "parameterValues"
-        ]
+        for item in yaml.safe_load((build_linux_package_bundle_dir / "parameter_values.yaml").read_text())["parameterValues"]
     }
-    conda_build_env = extract_job_entity(build_linux_package_template, "jobEnvironment", "CondaBuild Env")
+    package_build_env = extract_job_entity(build_linux_package_template, "jobEnvironment", "Package Build Env")
     build_package_template = extract_job_entity(build_linux_package_template, "step", "PackageBuild")
     reindex_channel_template = extract_job_entity(build_linux_package_template, "step", "ReindexCondaChannel")
 
-    conda_platform_host_requirements = yaml.safe_load(
-        (Path(__file__).parent / "conda_platform_host_requirements.yaml").read_text()
-    )
+    conda_platform_host_requirements = yaml.safe_load((Path(__file__).parent / "conda_platform_host_requirements.yaml").read_text())
 
     # Copy the scripts from the build_linux_package job bundle
-    shutil.copytree(build_linux_package_bundle_dir / "scripts", job_bundle_dir / "scripts", dirs_exist_ok=True)
+    shutil.copytree(
+        build_linux_package_bundle_dir / "scripts",
+        job_bundle_dir / "scripts",
+        dirs_exist_ok=True,
+    )
 
     collected_parameters = {}
     build_package_steps = []
@@ -236,8 +246,13 @@ def create_job_bundle(
         step_name_suffix = "".join(s.capitalize() for s in platform.split("-")) + "".join(
             s.capitalize() for s in platform_meta.get("variant", "").split("-")
         )
+        build_tool = platform_meta.get("buildTool", default_build_tool)
+
+        if build_tool not in ["conda-build", "rattler-build"]:
+            raise RuntimeError(f"Recipe provided an unsupported build tool {build_tool}")
 
         parameter_values[f"CondaPlatform_{step_name_suffix}"] = platform
+        parameter_values[f"BuildTool_{step_name_suffix}"] = build_tool
 
         # The platform_meta.yaml file can specify the local filename for the source archive.
         # If it's specified, provide it as one or more parameter values.
@@ -247,9 +262,7 @@ def create_job_bundle(
             if isinstance(source_archive_filename, str):
                 if not (archive_file_dir / source_archive_filename).is_file():
                     missing_source_archives.append(source_archive_filename)
-                parameter_values[f"OverrideSourceArchive1_{step_name_suffix}"] = str(
-                    archive_file_dir / source_archive_filename
-                )
+                parameter_values[f"OverrideSourceArchive1_{step_name_suffix}"] = str(archive_file_dir / source_archive_filename)
             elif isinstance(source_archive_filename, list):
                 if not 1 <= len(source_archive_filename) <= 2:
                     raise RuntimeError(
@@ -265,9 +278,7 @@ def create_job_bundle(
             if missing_source_archives:
                 print(f"ERROR: File(s) {', '.join(missing_source_archives)} not found in {archive_file_dir}.")
                 print(f"To submit the {recipe_dir.name} package build, you need these files.")
-                print(
-                    f"To acquire this archive, follow these instructions and place it in the {archive_file_dir} directory:"
-                )
+                print(f"To acquire this archive, follow these instructions and place it in the {archive_file_dir} directory:")
                 print(f"    {platform_meta['sourceDownloadInstructions']}")
                 sys.exit(1)
 
@@ -296,25 +307,34 @@ def create_job_bundle(
         # Get the conda platform-specific host requirements
         step.update(deepcopy(conda_platform_host_requirements[platform]))
         # If the platform-specific metadata has additional host requirements, add them too
-        update_host_requirements(step["hostRequirements"], platform_meta.get("additionalHostRequirements", {}))
+        update_host_requirements(
+            step["hostRequirements"],
+            platform_meta.get("additionalHostRequirements", {}),
+        )
 
         # If provided, write the conda_build_config.yaml file
-        if "condaBuildConfig" in platform_meta:
-            conda_build_config_path = job_bundle_dir / "data" / f"conda_build_config_{step_name_suffix}.yaml"
-            conda_build_config_path.parent.mkdir(exist_ok=True)
-            conda_build_config_path.write_text(yaml.safe_dump(platform_meta["condaBuildConfig"], sort_keys=False))
-            parameter_values[f"CondaBuildConfigFile_{step_name_suffix}"] = str(conda_build_config_path)
+        if "condaBuildConfig" in platform_meta or "variantConfig" in platform_meta:
+            variant_config_path = job_bundle_dir / "data" / f"variant_config_{step_name_suffix}.yaml"
+            variant_config_path.parent.mkdir(exist_ok=True)
+            variant_config_path.write_text(
+                json.dumps(
+                    platform_meta.get("condaBuildConfig", platform_meta.get("variantConfig")),
+                    indent=1,
+                    sort_keys=False,
+                )
+            )
+            parameter_values[f"VariantConfigFile_{step_name_suffix}"] = str(variant_config_path)
 
         build_package_steps.append(apply_regex_substitutions_to_object(step, renames))
 
-    print(f"Creating steps for conda platforms: {', '.join(sorted(p['platform'] for p in conda_platforms))}")
+    print(f"Creating steps for conda platforms: {', '.join(sorted(p['name'] for p in conda_platforms))}")
 
     # Process the channel reindex step
     reindex_step = reindex_channel_template["entity"]
     reindex_step["dependencies"] = [{"dependsOn": step["name"]} for step in build_package_steps]
     for param in reindex_channel_template["parameterDefinitions"]:
         collected_parameters[param["name"]] = param
-    for param in conda_build_env["parameterDefinitions"]:
+    for param in package_build_env["parameterDefinitions"]:
         collected_parameters[param["name"]] = param
 
     job_description = f"""
@@ -331,15 +351,16 @@ def create_job_bundle(
         "description": job_description,
         "parameterDefinitions": list(collected_parameters.values()),
         "jobEnvironments": [
-            conda_build_env["entity"],
+            package_build_env["entity"],
         ],
         "steps": [*build_package_steps, reindex_step],
     }
 
-    (job_bundle_dir / "template.yaml").write_text(yaml.safe_dump(job_template, sort_keys=False))
+    (job_bundle_dir / "template.yaml").write_text(json.dumps(job_template, indent=1, sort_keys=False))
     (job_bundle_dir / "parameter_values.yaml").write_text(
-        yaml.safe_dump(
+        json.dumps(
             {"parameterValues": [{"name": name, "value": value} for name, value in parameter_values.items()]},
+            indent=1,
             sort_keys=False,
         )
     )
@@ -363,11 +384,18 @@ def progress_callback(op_name):
 
 def main():
     parser = argparse.ArgumentParser(prog="submit-package-job")
-    parser.add_argument("recipe_dir", type=Path)
-    parser.add_argument("-q", "--queue")
-    parser.add_argument("--s3-channel")
-    parser.add_argument("-p", "--conda-platform", action="append")
-    parser.add_argument("--all-platforms", action="store_true")
+    parser.add_argument("recipe_dir", type=Path, help="The package build recipe to build on Deadline Cloud.")
+    parser.add_argument("-q", "--queue", default="Package", help="A prefix of the queue name to submit to.")
+    parser.add_argument("--s3-channel", help="The S3 conda channel to build the package to, in s3://S3_BUCKET/prefix_path format.")
+    parser.add_argument(
+        "-p",
+        "--conda-platform",
+        action="append",
+        help="The conda platform, as specified by the recipe's deadline-cloud.yaml. Can be wildcard * like filename globs.",
+    )
+    parser.add_argument(
+        "--all-platforms", action="store_true", help="Submit all the platforms specified by the recipe's deadline-cloud.yaml."
+    )
     args = parser.parse_args()
 
     if args.conda_platform and args.all_platforms:
@@ -377,7 +405,7 @@ def main():
     validate_recipe(recipe_dir)
 
     config = read_config()
-    set_queue_in_config(args.queue or "Package", config)
+    set_queue_in_config(args.queue, config)
 
     s3_channel_bucket, s3_channel_prefix = determine_s3_channel(args.s3_channel, config)
     print(f"Building packages into channel s3://{s3_channel_bucket}/{s3_channel_prefix}")
@@ -385,15 +413,23 @@ def main():
     # Read the recipe's submit metadata
     submit_meta = yaml.safe_load((recipe_dir / "deadline-cloud.yaml").read_text())
     conda_platforms = get_recipe_conda_platforms(
-        conda_platforms_meta=submit_meta.get("condaPlatforms"), conda_platform_names=args.conda_platform, all_platforms=args.all_platforms
+        conda_platforms_meta=submit_meta.get("condaPlatforms"),
+        conda_platform_patterns=["**"] if args.all_platforms else args.conda_platform,
     )
 
-    job_name = (
-        f"CondaBuild: {recipe_dir.name} ({', '.join(conda_platform['name'] for conda_platform in conda_platforms)})"
-    )
-    job_bundle_dir = Path(create_job_history_bundle_dir("BuildCondaPackage", job_name))
+    job_name = f"CondaBuild: {recipe_dir.name} ({', '.join(conda_platform['name'] for conda_platform in conda_platforms)})"
+    # TODO: The job name is shortened to 10 characters for this directory until the job attachments
+    #       implementation on Windows improves support for long filename paths. Restore it to just `job_name`
+    #       when that is fixed.
+    job_bundle_dir = Path(create_job_history_bundle_dir("CondaBuild", job_name[:10]))
+
+    default_build_tool = submit_meta.get("buildTool", "conda-build")
+
+    if default_build_tool not in ["conda-build", "rattler-build"]:
+        raise RuntimeError(f"Recipe provided an unsupported build tool {default_build_tool}")
 
     create_job_bundle(
+        default_build_tool=default_build_tool,
         job_bundle_dir=job_bundle_dir,
         recipe_dir=recipe_dir,
         archive_file_dir=Path(__file__).parent / "archive_files",
@@ -418,5 +454,5 @@ if __name__ == "__main__":
     try:
         main()
     except RuntimeError as e:
-        print(e)
+        print(f"{type(e).__name__}: {e}")
         sys.exit(1)


### PR DESCRIPTION
### Description
This PR adds support for `rattler-build` in addition to `conda-build`.  Rattler-build [github](https://github.com/prefix-dev/rattler-build), [blog](https://prefix.dev/blog/the_love_of_building_conda_packages) is a Rust based Conda package build tool. Development of `rattler-build` credits goto Mark Wiebe. I am only migrating the build tools to the open source community from internal usages.

Note that syntactically, `rattler-build` has slight differences in syntax. Refer to `rattler-build`'s documentation on converting from conda build [here](https://rattler.build/latest/converting_from_conda_build/) for specific details. 

The recipe for Blender 4.1 and 4.2 are migrated to `rattler-build`.

### Detailed Change Log
- WIP, reformatting some text.

### Testing
- WIP, will add details from a test build farm.